### PR TITLE
Un-needed imports

### DIFF
--- a/deselect/__init__.py
+++ b/deselect/__init__.py
@@ -1,6 +1,4 @@
 from fman import DirectoryPaneCommand
-from distutils.file_util import copy_file
-from distutils.dir_util import copy_tree
 import os.path
 
 class Deselect(DirectoryPaneCommand):


### PR DESCRIPTION
These imports from distutils aren't used by this plugin, and cause an error during the launch of fman if you don't already have them in your path.